### PR TITLE
feat: add dynamic video background to hero

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -12,8 +12,21 @@ const HeroSection = () => {
   };
 
   return (
-    <section className="py-12 md:py-16 lg:py-20 urban-bg">
-      <div className="container mx-auto px-4 md:px-6">
+    <section className="relative overflow-hidden py-12 md:py-16 lg:py-20">
+      <div className="absolute inset-0 -z-20">
+        <video
+          className="h-full w-full object-cover"
+          autoPlay
+          loop
+          muted
+          playsInline
+          poster="https://images.unsplash.com/photo-1600880292203-757bb62b4baf?auto=format&fit=crop&w=1400&q=80"
+        >
+          <source src="https://cdn.coverr.co/videos/coverr-young-adults-using-their-phones-5687/1080p.mp4" type="video/mp4" />
+        </video>
+      </div>
+      <div className="absolute inset-0 bg-slate-900/70 -z-10" aria-hidden="true" />
+      <div className="container relative z-10 mx-auto px-4 md:px-6">
         <div className="flex flex-col items-center text-center gap-6 animate-fade-in">
           <div className="w-32 h-32 mb-4 animate-float">
             <img 


### PR DESCRIPTION
## Summary
- replace the hero section's static canvas pattern with an autoplaying background video of people using their phones
- add a dark overlay and poster image so foreground content stays readable while the video loads

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caf05c4f40832eb3751590f96c3220